### PR TITLE
Stack with backing array

### DIFF
--- a/stacks.c
+++ b/stacks.c
@@ -8,46 +8,62 @@ struct _element {
 };
 
 struct _stack {
-    Element* top;
+    Item** data;
+    int size;
+    int capacity;
 };
+
+#define INITIAL_CAPACITY 32
 
 Stack* CreateStack() {
     Stack* stack = (Stack*)malloc(sizeof(Stack));
-    stack->top = NULL;
+    if (stack == NULL) return NULL;
+    stack->capacity = INITIAL_CAPACITY;
+    stack->size = 0;
+    stack->data = (Item**)malloc(sizeof(Item*) * stack->capacity);
+    if (stack->data == NULL) {
+        free(stack);
+        return NULL;
+    }
     return stack;
 }
 
 void Push(Stack* stack, Item* item) {
     if (stack == NULL) return;
-    Element* element = (Element*)malloc(sizeof(Element));
-    Element* buffer = stack->top;
-    stack->top = element;
-    stack->top->next = buffer;
-    stack->top->item = item;
+    if (stack->size >= stack->capacity) {
+        int newcap = stack->capacity * 2;
+        Item** tmp = (Item**)realloc(stack->data, sizeof(Item*) * newcap);
+        if (tmp == NULL) return; /* keep old buffer if realloc fails */
+        stack->data = tmp;
+        stack->capacity = newcap;
+    }
+    stack->data[stack->size++] = item;
 }
 
 Item* Pop(Stack* stack) {
-    if (IsStackEmpty(stack)) return NULL;
-    Element* top = stack->top;
-    Item* item = top->item;
-    stack->top = stack->top->next;
-    free(top);
-    return item;
+    if (stack == NULL || IsStackEmpty(stack)) return NULL;
+    return stack->data[--stack->size];
 }
 
 void ClearStack(Stack* stack) {
-    while (Pop(stack) != NULL);
+    if (stack == NULL) return;
+    free(stack->data);
+    stack->capacity = INITIAL_CAPACITY;
+    stack->size = 0;
+    stack->data = (Item**)malloc(sizeof(Item*) * stack->capacity);
+    if (stack->data == NULL) {
+        stack->capacity = 0;
+    }
 }
 
 int IsStackEmpty(Stack* stack) {
-    return (stack->top == NULL);
+    return (stack == NULL || stack->size == 0);
 }
 
 int IsInStack(Stack* stack, Item* item) {
-    Element* e = stack->top;
-    while (e != NULL) {
-        if (item == e->item) return 1;
-        e = e->next;
+    if (stack == NULL) return 0;
+    for (int i = 0; i < stack->size; ++i) {
+        if (stack->data[i] == item) return 1;
     }
     return 0;
 }

--- a/stacks.c
+++ b/stacks.c
@@ -13,7 +13,7 @@ struct _stack {
     int capacity;
 };
 
-#define INITIAL_CAPACITY 32
+#define INITIAL_CAPACITY 1
 
 Stack* CreateStack() {
     Stack* stack = (Stack*)malloc(sizeof(Stack));


### PR DESCRIPTION
Replace the stack with one with an backing array.

This saves us from individually allocating and freeing for each push. Saves lots of time.

Did some empirical testing and the best default size appears to be......... 1!

Did some more benchmarks, and the stacks appear to be used more usually at least up to 16 items, sometimes into the thousands of elements. I'll trust the benchmarks and exponential growth